### PR TITLE
Replace `git whatchanged` with `git log --raw`

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -318,7 +318,7 @@ class Git:
 
     def log(self, merge=False, first_parent=False, commit_time=False,
             reverse_order=False, paths: list = None):
-        cmd = 'whatchanged --pretty={}'.format('%ct' if commit_time else '%at')
+        cmd = 'log --raw --pretty={}'.format('%ct' if commit_time else '%at')
         if merge:         cmd += ' -m'
         if first_parent:  cmd += ' --first-parent'
         if reverse_order: cmd += ' --reverse'


### PR DESCRIPTION
## What

Replaces `git whatchanged` with `git log --raw`.

## Why

Fixes #28

`git whatchanged` has been deprecated. Running it fails with the deprecation message below on `ubuntu-latest`.

```
'git whatchanged' is nominated for removal.
If you still use this command, please add an extra
option, '--i-still-use-this', on the command line
and let us know you still use it by sending an e-mail
to <git@vger.kernel.org>.  Thanks.
fatal: refusing to run without --i-still-use-this
```